### PR TITLE
feat(glue): add support for Glue 5.0 logging and security permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ A Terraform module that creates a Glue job.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.95.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.40.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.95.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.40.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ A Terraform module that creates a Glue job.
 | [aws_glue_job.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_job) | resource |
 | [aws_glue_trigger.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_trigger) | resource |
 | [aws_iam_role_policy.associate_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.associate_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ A Terraform module that creates a Glue job.
 | Name | Type |
 |------|------|
 | [aws_cloudwatch_log_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.error](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.output](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_glue_job.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_job) | resource |
 | [aws_glue_trigger.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_trigger) | resource |
+| [aws_iam_role_policy.associate_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_policy_document.associate_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
@@ -44,7 +48,7 @@ A Terraform module that creates a Glue job.
 | <a name="input_execution_role"></a> [execution\_role](#input\_execution\_role) | Configuration for Glue execution IAM role | <pre>object({<br/>    additional_policy_arns = optional(set(string), [])<br/>    create_policy          = optional(bool)<br/>    policy                 = optional(string)<br/>  })</pre> | `{}` | no |
 | <a name="input_execution_role_custom"></a> [execution\_role\_custom](#input\_execution\_role\_custom) | Optional existing IAM role for Glue execution. Overrides the role configured in the execution\_role variable. | <pre>object({<br/>    arn = string<br/>  })</pre> | `null` | no |
 | <a name="input_glue_version"></a> [glue\_version](#input\_glue\_version) | The Glue version to use | `string` | `"4.0"` | no |
-| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The kms key id of the AWS KMS Customer Managed Key to be used to encrypt the log data | `string` | `null` | no |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN of the KMS Customer Managed Key to encrypt the CloudWatch log group(s) | `string` | `null` | no |
 | <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | The cloudwatch log group retention in days | `number` | `365` | no |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | The maximum number of data processing units that can be allocated | `number` | `null` | no |
 | <a name="input_max_retries"></a> [max\_retries](#input\_max\_retries) | The maximum number of times to retry a failing job | `number` | `null` | no |
@@ -63,4 +67,7 @@ A Terraform module that creates a Glue job.
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN of the Glue job |
 | <a name="output_id"></a> [id](#output\_id) | The Glue job name |
+| <a name="output_log_group_error_name"></a> [log\_group\_error\_name](#output\_log\_group\_error\_name) | Name of the CloudWatch error log group managed by the module (Glue 5.0+) |
+| <a name="output_log_group_name"></a> [log\_group\_name](#output\_log\_group\_name) | Name of the CloudWatch log group managed by the module (Glue 4.x only) |
+| <a name="output_log_group_output_name"></a> [log\_group\_output\_name](#output\_log\_group\_output\_name) | Name of the CloudWatch output log group managed by the module (Glue 5.0+) |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ A Terraform module that creates a Glue job.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.95.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.95.0 |
 
 ## Modules
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -28,9 +28,13 @@ Any existing CloudWatch dashboards, metric filters, or log insights queries poin
 
 The new group names are exposed via the `log_group_error_name` and `log_group_output_name` outputs to make referencing them from other resources straightforward.
 
+Rolling back to `glue_version = "4.0"` reverses these changes: `aws_cloudwatch_log_group.error` and `aws_cloudwatch_log_group.output` are destroyed and `aws_cloudwatch_log_group.default` is re-created. CloudWatch deletes log data when a log group is destroyed, so export any logs you need to retain before rolling back.
+
 ### Security configuration and `logs:AssociateKmsKey`
 
 When `security_configuration` is set, the module now automatically grants `logs:AssociateKmsKey` on `/aws-glue/jobs/*` to the Glue execution role. This permission is required by AWS for all Glue versions when CloudWatch KMS encryption is enabled in the security configuration — without it, continuous logging is silently disabled. No action is required from callers — if you were previously granting this permission manually, it can be removed.
+
+When using `execution_role_custom` alongside `security_configuration`, you must grant `logs:AssociateKmsKey` on `arn:aws:logs:<region>:<account>:log-group:/aws-glue/jobs/*` to the role yourself — the module only adds this permission to the role it creates.
 
 ## Upgrading to v2.0.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,34 @@
 
 This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
 
+## Upgrading to v3.0.0
+
+This release adds full Glue 5.0 logging support including automatic CloudWatch log group management, KMS encryption, and the `logs:AssociateKmsKey` IAM permission required for security configurations.
+
+### No action required for Glue 4.x callers
+
+If you are not changing `glue_version`, the module behaves identically to v2.x. No variable changes, no resource replacements.
+
+### Migrating from `glue_version = "4.0"` to `"5.0"`
+
+Glue 5.0 uses a different logging architecture. When you upgrade `glue_version` to `"5.0"` the following resource changes will appear in your plan — all are expected and intentional:
+
+* `aws_cloudwatch_log_group.default` is **destroyed** (the single log group used by Glue 4.x)
+* `aws_cloudwatch_log_group.error` and `aws_cloudwatch_log_group.output` are **created** — the two log groups Glue 5.0 writes to
+
+The new group names follow the Glue 5.0 convention:
+
+* Without a security configuration: `/aws-glue/jobs/<job-name>/error` and `/aws-glue/jobs/<job-name>/output`
+* With a security configuration: `/aws-glue/jobs/<security-config>-role/<role>/error` and `.../output`
+
+Any existing CloudWatch dashboards, metric filters, or log insights queries pointing to the old group name (`/aws-glue/jobs/<job-name>`) will need to be updated to the new `/error` and `/output` suffixed group names.
+
+The new group names are exposed via the `log_group_error_name` and `log_group_output_name` outputs to make referencing them from other resources straightforward.
+
+### Security configuration and `logs:AssociateKmsKey`
+
+When `security_configuration` is set, the module now automatically grants `logs:AssociateKmsKey` on `/aws-glue/jobs/*` to the Glue execution role. This permission is required by Glue 5.0 on every job run start when CloudWatch KMS encryption is enabled in the security configuration. No action is required from callers — if you were previously granting this permission manually, it can be removed.
+
 ## Upgrading to v2.0.0
 
 ### Variables (v2.0.0)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,11 +6,21 @@ This document captures required refactoring on your part when upgrading to a mod
 
 This release adds full Glue 5.0 logging support including automatic CloudWatch log group management, KMS encryption, and the `logs:AssociateKmsKey` IAM permission required for security configurations.
 
-### No action required for Glue 4.x callers
+### Glue 4.x callers
 
-If you are not changing `glue_version`, no variable changes or resource replacements are needed. However, if you already have `security_configuration` set, you will see one new resource in your plan:
+If you are not changing `glue_version`, no variable changes or resource replacements are needed. However, if you already have `security_configuration` set, you will see new resources in your plan:
 
 * `aws_iam_role_policy.associate_kms_key` is **created** — this grants `logs:AssociateKmsKey` to the Glue execution role, which is required by AWS whenever CloudWatch KMS encryption is enabled in a security configuration (for all Glue versions). This is expected and safe. If you were previously granting this permission manually, it can be removed.
+* If you also have `kms_key_id` set, `aws_cloudwatch_log_group.default` is **created** with the name `/aws-glue/jobs/<job-name>-<security-config>` — the module now manages the log group Glue actually writes to, so KMS encryption and retention are Terraform-managed.
+
+> [!WARNING]
+> If your job has logged successfully before, Glue has already created the `/aws-glue/jobs/<job-name>-<security-config>` log group and the apply will fail with `ResourceAlreadyExistsException`. Import the existing log group before applying:
+>
+> ```sh
+> terraform import 'module.<your-module-name>.aws_cloudwatch_log_group.default[0]' '/aws-glue/jobs/<job-name>-<security-config>'
+> ```
+>
+> After import, review the plan: the module will set the KMS key and retention on the imported group, which is the intended end state.
 
 ### Migrating from `glue_version = "4.0"` to `"5.0"`
 
@@ -18,6 +28,15 @@ Glue 5.0 uses a different logging architecture. When you upgrade `glue_version` 
 
 * `aws_cloudwatch_log_group.default` is **destroyed** (the single log group used by Glue 4.x)
 * `aws_cloudwatch_log_group.error` and `aws_cloudwatch_log_group.output` are **created** — the two log groups Glue 5.0 writes to
+
+> [!WARNING]
+> Destroying `aws_cloudwatch_log_group.default` **deletes all log data it contains**. If you need to retain the historical Glue 4.x logs, remove the log group from state instead of letting Terraform destroy it — the group stays in AWS (unmanaged) and its existing retention policy continues to expire data naturally:
+>
+> ```sh
+> terraform state rm 'module.<your-module-name>.aws_cloudwatch_log_group.default[0]'
+> ```
+>
+> Run this before applying the `glue_version = "5.0"` change. Alternatively, export the logs to S3 first using a [CloudWatch Logs export task](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/S3ExportTasks.html).
 
 The new group names follow the Glue 5.0 convention:
 
@@ -28,7 +47,7 @@ Any existing CloudWatch dashboards, metric filters, or log insights queries poin
 
 The new group names are exposed via the `log_group_error_name` and `log_group_output_name` outputs to make referencing them from other resources straightforward.
 
-Rolling back to `glue_version = "4.0"` reverses these changes: `aws_cloudwatch_log_group.error` and `aws_cloudwatch_log_group.output` are destroyed and `aws_cloudwatch_log_group.default` is re-created. CloudWatch deletes log data when a log group is destroyed, so export any logs you need to retain before rolling back.
+Rolling back to `glue_version = "4.0"` reverses these changes: `aws_cloudwatch_log_group.error` and `aws_cloudwatch_log_group.output` are destroyed and `aws_cloudwatch_log_group.default` is re-created. CloudWatch deletes log data when a log group is destroyed, so before rolling back either export the logs you need to retain or `terraform state rm` the `error` and `output` log groups, as described in the warning above.
 
 ### Security configuration and `logs:AssociateKmsKey`
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,7 +8,9 @@ This release adds full Glue 5.0 logging support including automatic CloudWatch l
 
 ### No action required for Glue 4.x callers
 
-If you are not changing `glue_version`, the module behaves identically to v2.x. No variable changes, no resource replacements.
+If you are not changing `glue_version`, no variable changes or resource replacements are needed. However, if you already have `security_configuration` set, you will see one new resource in your plan:
+
+* `aws_iam_role_policy.associate_kms_key` is **created** — this grants `logs:AssociateKmsKey` to the Glue execution role, which is required by AWS whenever CloudWatch KMS encryption is enabled in a security configuration (for all Glue versions). This is expected and safe. If you were previously granting this permission manually, it can be removed.
 
 ### Migrating from `glue_version = "4.0"` to `"5.0"`
 
@@ -28,7 +30,7 @@ The new group names are exposed via the `log_group_error_name` and `log_group_ou
 
 ### Security configuration and `logs:AssociateKmsKey`
 
-When `security_configuration` is set, the module now automatically grants `logs:AssociateKmsKey` on `/aws-glue/jobs/*` to the Glue execution role. This permission is required by Glue 5.0 on every job run start when CloudWatch KMS encryption is enabled in the security configuration. No action is required from callers — if you were previously granting this permission manually, it can be removed.
+When `security_configuration` is set, the module now automatically grants `logs:AssociateKmsKey` on `/aws-glue/jobs/*` to the Glue execution role. This permission is required by AWS for all Glue versions when CloudWatch KMS encryption is enabled in the security configuration — without it, continuous logging is silently disabled. No action is required from callers — if you were previously granting this permission manually, it can be removed.
 
 ## Upgrading to v2.0.0
 

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,7 +1,26 @@
 resource "aws_cloudwatch_log_group" "default" {
-  count = local.create_log_group ? 1 : 0
+  count = local.create_log_group_v4 ? 1 : 0
 
-  name              = "/aws-glue/jobs/${var.name}"
+  name              = local.log_group_prefix
+  kms_key_id        = var.kms_key_id
+  retention_in_days = var.log_retention_days
+  tags              = var.tags
+}
+
+# Glue 5.0+: Terraform pre-creates both log groups so KMS encryption and retention are managed consistently.
+resource "aws_cloudwatch_log_group" "error" {
+  count = local.create_log_group_v5 ? 1 : 0
+
+  name              = local.log_group_v5_error
+  kms_key_id        = var.kms_key_id
+  retention_in_days = var.log_retention_days
+  tags              = var.tags
+}
+
+resource "aws_cloudwatch_log_group" "output" {
+  count = local.create_log_group_v5 ? 1 : 0
+
+  name              = local.log_group_v5_output
   kms_key_id        = var.kms_key_id
   retention_in_days = var.log_retention_days
   tags              = var.tags

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_log_group" "default" {
   count = local.create_log_group_v4 ? 1 : 0
 
-  name              = local.log_group_prefix
+  name              = local.log_group_v4_name
   kms_key_id        = var.kms_key_id
   retention_in_days = var.log_retention_days
   tags              = var.tags

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0"
+      version = ">= 6.40.0"
     }
   }
-  required_version = ">= 1.3"
+  required_version = ">= 1.6.0"
 }

--- a/examples/security-configuration/main.tf
+++ b/examples/security-configuration/main.tf
@@ -1,0 +1,91 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+data "aws_kms_key" "example" {
+  key_id = "alias/example-key"
+}
+
+resource "aws_glue_security_configuration" "example" {
+  name = "example-security-config"
+
+  encryption_configuration {
+    cloudwatch_encryption {
+      cloudwatch_encryption_mode = "SSE-KMS"
+      kms_key_arn                = data.aws_kms_key.example.arn
+    }
+
+    job_bookmarks_encryption {
+      job_bookmarks_encryption_mode = "CSE-KMS"
+      kms_key_arn                   = data.aws_kms_key.example.arn
+    }
+
+    s3_encryption {
+      kms_key_arn        = data.aws_kms_key.example.arn
+      s3_encryption_mode = "SSE-KMS"
+    }
+  }
+}
+
+# Glue 5.0 with a security configuration:
+# - The module pre-creates /aws-glue/jobs/<security-config>-role/<role>/error and .../output
+#   with KMS encryption and retention already applied.
+# - logs:AssociateKmsKey is granted automatically on the execution role.
+# - Pass kms_key_id matching the security configuration's CloudWatch KMS key so the
+#   pre-created log groups use the same key Glue expects to associate.
+# - Pass the KMS key ARN in the execution role policy for S3 and job bookmark access.
+module "example_glue_job" {
+  source = "../.."
+
+  name                   = "example-glue-job"
+  glue_version           = "5.0"
+  kms_key_id             = data.aws_kms_key.example.arn
+  log_retention_days     = 90
+  max_retries            = 1
+  number_of_workers      = 2
+  schedule               = "cron(0 12 * * ? *)"
+  script_location        = "s3://example-bucket/location/script.py"
+  security_configuration = aws_glue_security_configuration.example.name
+  trigger_type           = "SCHEDULED"
+  worker_type            = "G.1X"
+
+  default_arguments = {
+    "--VAR1" = "some value"
+  }
+
+  execution_role = {
+    create_policy = true
+    policy        = data.aws_iam_policy_document.glue_job_policy.json
+  }
+
+  tags = {
+    Environment = "development"
+    Stack       = "glue"
+  }
+}
+
+data "aws_iam_policy_document" "glue_job_policy" {
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:ListBucket",
+    ]
+    resources = [
+      "arn:aws:s3:::example-bucket",
+      "arn:aws:s3:::example-bucket/*",
+    ]
+  }
+
+  # Required for S3 and job bookmark encryption via the security configuration
+  statement {
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey",
+      "kms:ReEncrypt*",
+    ]
+    resources = [data.aws_kms_key.example.arn]
+  }
+}

--- a/examples/security-configuration/main.tf
+++ b/examples/security-configuration/main.tf
@@ -6,6 +6,20 @@ data "aws_kms_key" "example" {
   key_id = "alias/example-key"
 }
 
+# The KMS key policy must grant the CloudWatch Logs service principal permission to use
+# the key, otherwise log group creation with kms_key_id set will fail. Add a statement
+# like the following to the key policy:
+#
+#   {
+#     "Sid": "Allow CloudWatch Logs to use the key",
+#     "Effect": "Allow",
+#     "Principal": { "Service": "logs.<region>.amazonaws.com" },
+#     "Action": ["kms:Encrypt*","kms:Decrypt*","kms:ReEncrypt*","kms:GenerateDataKey*","kms:Describe*"],
+#     "Resource": "*"
+#   }
+#
+# This is separate from the execution role's KMS permissions below, which cover S3 and job bookmark encryption.
+
 resource "aws_glue_security_configuration" "example" {
   name = "example-security-config"
 
@@ -89,3 +103,4 @@ data "aws_iam_policy_document" "glue_job_policy" {
     resources = [data.aws_kms_key.example.arn]
   }
 }
+

--- a/examples/security-configuration/versions.tf
+++ b/examples/security-configuration/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0.0"
+    }
+  }
+  required_version = ">= 1.3"
+}

--- a/examples/security-configuration/versions.tf
+++ b/examples/security-configuration/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.95.0"
+      version = ">= 6.40.0"
     }
   }
-  required_version = ">= 1.3"
+  required_version = ">= 1.6.0"
 }

--- a/examples/security-configuration/versions.tf
+++ b/examples/security-configuration/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0"
+      version = ">= 5.95.0"
     }
   }
   required_version = ">= 1.3"

--- a/iam.tf
+++ b/iam.tf
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "associate_kms_key" {
 
   statement {
     actions   = ["logs:AssociateKmsKey"]
-    resources = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws-glue/jobs/*"]
+    resources = ["arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws-glue/jobs/*"]
   }
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -1,3 +1,6 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
 module "job_execution_role" {
   count = var.execution_role_custom == null ? 1 : 0
 
@@ -24,7 +27,7 @@ data "aws_iam_policy_document" "associate_kms_key" {
 
   statement {
     actions   = ["logs:AssociateKmsKey"]
-    resources = ["arn:aws:logs:*:*:log-group:/aws-glue/jobs/*"]
+    resources = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws-glue/jobs/*"]
   }
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -15,3 +15,23 @@ module "job_execution_role" {
     "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole",
   ]), var.execution_role.additional_policy_arns)
 }
+
+# When a security configuration with CloudWatch KMS encryption is active, Glue calls
+# logs:AssociateKmsKey on every job run start. This policy ensures the execution role
+# is authorised regardless of whether log groups were pre-created by Terraform.
+data "aws_iam_policy_document" "associate_kms_key" {
+  count = var.security_configuration != null && var.execution_role_custom == null ? 1 : 0
+
+  statement {
+    actions   = ["logs:AssociateKmsKey"]
+    resources = ["arn:aws:logs:*:*:log-group:/aws-glue/jobs/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "associate_kms_key" {
+  count = var.security_configuration != null && var.execution_role_custom == null ? 1 : 0
+
+  name   = "${var.name}-associate-kms-key"
+  role   = element(split("/", module.job_execution_role[0].arn), 1)
+  policy = data.aws_iam_policy_document.associate_kms_key[0].json
+}

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,19 @@
 locals {
-  create_log_group = var.security_configuration == null && var.continuous_logging.enabled && var.continuous_logging.log_group_name == null
+  glue_major_version = tonumber(split(".", var.glue_version)[0])
+  role_arn           = var.execution_role_custom != null ? var.execution_role_custom.arn : module.job_execution_role[0].arn
+  role_name          = element(split("/", local.role_arn), 1)
+  log_group_prefix   = coalesce(var.continuous_logging.log_group_name, "/aws-glue/jobs/${var.name}")
+
+  # Glue 4.x: manage the log group when there is no security config, or when a KMS key is explicitly provided
+  manage_log_group_v4 = var.security_configuration == null || var.kms_key_id != null
+  create_log_group_v4 = local.glue_major_version < 5 && var.continuous_logging.enabled && local.manage_log_group_v4 && var.continuous_logging.log_group_name == null
+
+  # Glue 5.0+: always create separate error and output log groups so retention and KMS are Terraform-managed
+  create_log_group_v5 = local.glue_major_version >= 5 && var.continuous_logging.enabled && var.continuous_logging.log_group_name == null
+
+  # Glue 5.0 log group names: with a security configuration AWS appends <SecConfig>-role/<Role> to the prefix
+  log_group_v5_error  = var.security_configuration != null ? "/aws-glue/jobs/${var.security_configuration}-role/${local.role_name}/error" : "${local.log_group_prefix}/error"
+  log_group_v5_output = var.security_configuration != null ? "/aws-glue/jobs/${var.security_configuration}-role/${local.role_name}/output" : "${local.log_group_prefix}/output"
 }
 
 resource "aws_glue_job" "default" {
@@ -25,9 +39,19 @@ resource "aws_glue_job" "default" {
     {
       "--enable-continuous-cloudwatch-log" : var.continuous_logging.enabled,
     },
-    var.continuous_logging.enabled && var.security_configuration == null ?
+    # Glue 4.x: --continuous-log-logGroup points to the single managed log group
+    var.continuous_logging.enabled && local.glue_major_version < 5 && local.manage_log_group_v4 ?
     {
       "--continuous-log-logGroup" : var.continuous_logging.log_group_name != null ? var.continuous_logging.log_group_name : aws_cloudwatch_log_group.default[0].name,
+    } : {},
+    # Glue 5.0 with security config: log group names are fixed by AWS convention
+    # (<SecConfig>-role/<Role>/error|output) so no argument is needed — Terraform
+    # pre-creates those exact groups in cloudwatch.tf with KMS and retention.
+    # Without security config: pass --custom-logGroup-prefix to avoid the shared
+    # /aws-glue/jobs/error group that all jobs in the account would otherwise share.
+    var.continuous_logging.enabled && local.glue_major_version >= 5 && var.security_configuration == null ?
+    {
+      "--custom-logGroup-prefix" : local.log_group_prefix,
     } : {}
   )
 }

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,10 @@ locals {
   manage_log_group_v4 = var.security_configuration == null || var.kms_key_id != null
   create_log_group_v4 = local.glue_major_version < 5 && var.continuous_logging.enabled && local.manage_log_group_v4 && var.continuous_logging.log_group_name == null
 
+  # Glue 4.x log group name: with a security configuration AWS appends -<SecConfig> to the prefix when writing logs,
+  # so pre-create the group at the name Glue will actually use.
+  log_group_v4_name = var.security_configuration != null ? "${local.log_group_prefix}-${var.security_configuration}" : local.log_group_prefix
+
   # Glue 5.0+: always create separate error and output log groups so retention and KMS are Terraform-managed
   create_log_group_v5 = local.glue_major_version >= 5 && var.continuous_logging.enabled && var.continuous_logging.log_group_name == null
 
@@ -42,7 +46,7 @@ resource "aws_glue_job" "default" {
     # Glue 4.x: --continuous-log-logGroup points to the single managed log group
     var.continuous_logging.enabled && local.glue_major_version < 5 && local.manage_log_group_v4 ?
     {
-      "--continuous-log-logGroup" : var.continuous_logging.log_group_name != null ? var.continuous_logging.log_group_name : aws_cloudwatch_log_group.default[0].name,
+      "--continuous-log-logGroup" : var.continuous_logging.log_group_name != null ? var.continuous_logging.log_group_name : local.log_group_prefix,
     } : {},
     # Glue 5.0 with security config: log group names are fixed by AWS convention
     # (<SecConfig>-role/<Role>/error|output) so no argument is needed — Terraform

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   glue_major_version = tonumber(split(".", var.glue_version)[0])
   role_arn           = var.execution_role_custom != null ? var.execution_role_custom.arn : module.job_execution_role[0].arn
-  role_name          = element(split("/", local.role_arn), 1)
+  role_name          = element(split("/", local.role_arn), length(split("/", local.role_arn)) - 1)
   log_group_prefix   = coalesce(var.continuous_logging.log_group_name, "/aws-glue/jobs/${var.name}")
 
   # Glue 4.x: manage the log group when there is no security config, or when a KMS key is explicitly provided

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,18 @@ output "id" {
   value       = aws_glue_job.default.id
   description = "The Glue job name"
 }
+
+output "log_group_name" {
+  value       = local.glue_major_version < 5 ? try(aws_cloudwatch_log_group.default[0].name, null) : null
+  description = "Name of the CloudWatch log group managed by the module (Glue 4.x only)"
+}
+
+output "log_group_error_name" {
+  value       = local.glue_major_version >= 5 ? try(aws_cloudwatch_log_group.error[0].name, null) : null
+  description = "Name of the CloudWatch error log group managed by the module (Glue 5.0+)"
+}
+
+output "log_group_output_name" {
+  value       = local.glue_major_version >= 5 ? try(aws_cloudwatch_log_group.output[0].name, null) : null
+  description = "Name of the CloudWatch output log group managed by the module (Glue 5.0+)"
+}

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.95.0"
+      version = ">= 6.40.0"
     }
   }
-  required_version = ">= 1.3"
+  required_version = ">= 1.6.0"
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0"
+      version = ">= 5.95.0"
     }
   }
   required_version = ">= 1.3"

--- a/variables.tf
+++ b/variables.tf
@@ -70,7 +70,7 @@ variable "glue_version" {
 variable "kms_key_id" {
   type        = string
   default     = null
-  description = "The kms key id of the AWS KMS Customer Managed Key to be used to encrypt the log data"
+  description = "The ARN of the KMS Customer Managed Key to encrypt the CloudWatch log group(s)"
 }
 
 variable "log_retention_days" {


### PR DESCRIPTION
## :hammer_and_wrench: Summary

This pull request introduces full support for [AWS Glue 5.0 logging](https://docs.aws.amazon.com/glue/latest/dg/migrating-version-50.html#enable-continous-logging-changes-glue-50), including automatic management of CloudWatch log groups, KMS encryption, and the necessary IAM permissions for security configurations. The changes are backward compatible for Glue 4.x users, but when upgrading to Glue 5.0, new log group resources and IAM policies are managed automatically. Outputs have been enhanced to expose new log group names for easier integration.

## :rocket: Motivation

**Glue 5.0 Logging Support:**
- Adds automatic creation and management of separate CloudWatch log groups for error and output logs when using Glue 5.0 (`cloudwatch.tf`, `main.tf`, `outputs.tf`). [[1]](diffhunk://#diff-8979cc7432f545eb785994178ab97e88921b396e27e87deb538ef14a0efbd1b9L2-R23) [[2]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL2-R16) [[3]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL28-R54) [[4]](diffhunk://#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7R10-R24)
- Exposes new outputs for the error and output log group names to simplify referencing them in other resources (`outputs.tf`).

## :pencil: Additional Information

**Security and Permissions:**
- Automatically grants the `logs:AssociateKmsKey` IAM permission to the Glue execution role when a security configuration is set, as required by Glue 5.0 with KMS encryption (`iam.tf`).

**Backward Compatibility and Upgrade Guidance:**
- No changes are required for Glue 4.x users; the module is backward compatible unless `glue_version` is changed (`UPGRADING.md`).
- Provides detailed upgrade instructions and documents expected resource changes when migrating to Glue 5.0 (`UPGRADING.md`).

**Variable Description Update:**
- Clarifies the description of the `kms_key_id` variable to indicate it expects a KMS ARN (`variables.tf`).
