### PR TITLE
enhancement(glue): add configurable max_concurrent_runs for glue job

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ A Terraform module that creates a Glue job.
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN of the KMS Customer Managed Key to encrypt the CloudWatch log group(s) | `string` | `null` | no |
 | <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | The cloudwatch log group retention in days | `number` | `365` | no |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | The maximum number of data processing units that can be allocated | `number` | `null` | no |
+| <a name="input_max_concurrent_runs"></a> [max\_concurrent\_runs](#input\_max\_concurrent\_runs) | The maximum number of concurrent runs allowed for the job | `number` | `1` | no |
 | <a name="input_max_retries"></a> [max\_retries](#input\_max\_retries) | The maximum number of times to retry a failing job | `number` | `null` | no |
 | <a name="input_number_of_workers"></a> [number\_of\_workers](#input\_number\_of\_workers) | The number of workers that are allocated when the job runs | `string` | `null` | no |
 | <a name="input_python_version"></a> [python\_version](#input\_python\_version) | The Python version (2, 3 or 3.9) being used to execute a Python shell job | `string` | `"3"` | no |

--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,10 @@ resource "aws_glue_job" "default" {
     script_location = var.script_location
   }
 
+  execution_property {
+    max_concurrent_runs = var.max_concurrent_runs
+  }
+
   default_arguments = merge(var.default_arguments,
     {
       "--enable-continuous-cloudwatch-log" : var.continuous_logging.enabled,

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,12 @@ variable "max_capacity" {
   description = "The maximum number of data processing units that can be allocated"
 }
 
+variable "max_concurrent_runs" {
+  type        = number
+  default     = 1
+  description = "The maximum number of concurrent runs allowed for the job"
+}
+
 variable "max_retries" {
   type        = number
   default     = null


### PR DESCRIPTION


## :hammer_and_wrench: Summary

 Add an optional `max_concurrent_runs` variable to control the job's `execution_property`. Defaults to 1 to preserve existing behavior.
 max_concurrent_runs controls the maximum number of concurrent runs allowed for a job

## :rocket: Motivation
To support  parallel execution runs of glue jobs at the same time. Exposing the `max_concurrent_runs` makes this configurable to support such use cases

## :pencil: Additional Information

- The default of `1` matches AWS Glue's own default, so existing deployments see no change to their plan beyond the new (no-op) value.
  - Reference: [`aws_glue_job` execution_property](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_job#execution_property)

